### PR TITLE
Django 1.7

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -45,7 +45,8 @@ def main():
 
     test_runner = TestRunner(verbosity=1, interactive=False, failfast=False)
     warnings.simplefilter("ignore")
-    django.setup()
+    if django.VERSION >= (1, 7):
+        django.setup()
     failures = test_runner.run_tests(['classytags'])
     sys.exit(failures)
 


### PR DESCRIPTION
To run the tests with Django-1.7 you need to call django.setup() before anything wants to access the App registry in a standalone script. See https://docs.djangoproject.com/en/dev/releases/1.7/#standalone-scripts for details.
