### PR TITLE
Added ppc64le architecture support on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,32 @@ matrix:
     # Django 3.1, always run the lowest supported version
     - python: 3.6
       env: DJANGO='dj31'
+    # Adding jobs for ppc64le architecture
+    - python: 3.5
+      env: TOX_ENV='flake8'
+      arch: ppc64le
+    - python: 3.5
+      env: TOX_ENV='isort'
+      arch: ppc64le
+    # Django 2.2, run all supported versions for LTS releases
+    - python: 3.5
+      env: DJANGO='dj22'
+      arch: ppc64le
+    - python: 3.6
+      env: DJANGO='dj22'
+      arch: ppc64le
+    - python: 3.7
+      env: DJANGO='dj22'
+      arch: ppc64le
+    - python: 3.8
+      env: DJANGO='dj22'
+      arch: ppc64le
+    - python: 3.6
+      env: DJANGO='dj30'
+      arch: ppc64le
+    - python: 3.6
+      env: DJANGO='dj31'
+      arch: ppc64le
 
 install:
   - pip install coverage isort tox


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) architecture support on travis-ci in the branch and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.
https://travis-ci.com/github/kishorkunal-raj/django-classy-tags/builds/186435796

Please have a look.

Regards,
Kishor Kunal Raj