### PR TITLE
ci: add support for django 3.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
           dj30_cms37.txt,
           dj30_cms38.txt,
           dj31_cms38.txt,
+          dj32_cms39.txt,
         ]
         os: [
           ubuntu-20.04,

--- a/tests/requirements/dj32_cms39.txt
+++ b/tests/requirements/dj32_cms39.txt
@@ -1,0 +1,4 @@
+-r base.txt
+
+Django>=3.2,<3.3
+django-cms>=3.9,<4

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 envlist =
     flake8
     isort
-    py{35,36,37,38}-dj{22}
-    py{36,37,38}-dj{30,31}
+    py{36,37,38,39}-dj{22}
+    py{36,37,38,39}-dj{30,31,32}
 
 skip_missing_interpreters=True
 
@@ -41,6 +41,7 @@ deps =
     dj22: Django>=2.2,<3.0
     dj30: Django>=3.0,<3.1
     dj31: Django>=3.1,<3.2
+    dj32: Django>=3.2,<3.3
 commands =
     {envpython} --version
     {env:COMMAND:coverage} erase


### PR DESCRIPTION
**Description**
This PR supports Django 3.2 in CI as the Open edX community effort to give Django 3.2 support to all its dependencies. [Here](https://github.com/edx/upgrades/issues/39)'s the issue if you're interested. 