### PR TITLE
Added actions for test & live pypi releases.

### DIFF
--- a/.github/workflows/publish-to-live-pypi.yml
+++ b/.github/workflows/publish-to-live-pypi.yml
@@ -1,0 +1,38 @@
+name: Publish Python 🐍 distributions 📦 to pypi
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  build-n-publish:
+    name: Build and publish Python 🐍 distributions 📦 to pypi
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.9
+
+    - name: Install pypa/build
+      run: >-
+        python -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: >-
+        python -m
+        build
+        --sdist
+        --wheel
+        --outdir dist/
+        .
+
+    - name: Publish distribution 📦 to PyPI
+      if: startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish-to-live-pypi.yml
+++ b/.github/workflows/publish-to-live-pypi.yml
@@ -35,4 +35,5 @@ jobs:
       if: startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@master
       with:
+        user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish-to-live-pypi.yml
+++ b/.github/workflows/publish-to-live-pypi.yml
@@ -3,7 +3,7 @@ name: Publish Python 🐍 distributions 📦 to pypi
 on:
   release:
     types:
-      - created
+      - published
 
 jobs:
   build-n-publish:

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -1,6 +1,9 @@
 name: Publish Python 🐍 distributions 📦 to TestPyPI
 
-on: push
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   build-n-publish:
@@ -31,6 +34,7 @@ jobs:
     - name: Publish distribution 📦 to Test PyPI
       uses: pypa/gh-action-pypi-publish@master
       with:
+        user: __token__
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
         skip_existing: true

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -1,0 +1,36 @@
+name: Publish Python 🐍 distributions 📦 to TestPyPI
+
+on: push
+
+jobs:
+  build-n-publish:
+    name: Build and publish Python 🐍 distributions 📦 to TestPyPI
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.9
+
+    - name: Install pypa/build
+      run: >-
+        python -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: >-
+        python -m
+        build
+        --sdist
+        --wheel
+        --outdir dist/
+        .
+
+    - name: Publish distribution 📦 to Test PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/
+        skip_existing: true


### PR DESCRIPTION
This adds github actions to do release automation to pypi.

One action will do test releases, then final releases are triggered when a release is created.

This requires 2 secrets adding to the repo to authenticate with pypi.

Secrets can be added here;
https://github.com/django-cms/django-classy-tags/settings/secrets/actions

The expected secret names are;

* `TEST_PYPI_API_TOKEN` - https://test.pypi.org/account/login/
* `PYPI_API_TOKEN` - https://pypi.org/account/login/
