### PR TITLE
fix: Inclusion of full tests package in tarball [#69]

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,6 @@
 include LICENSE
 include README.rst
 recursive-exclude * *.py[co]
+recursive-include tests *.html
+recursive-include tests *.py
+recursive-include tests *.txt


### PR DESCRIPTION
This, hopefully, fixes #69 by including all of the tests package in the sdist tarball.