### PR TITLE
tests: start testing Django 4.1 and Django `main` branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,15 +4,23 @@ on: [push, pull_request]
 
 jobs:
   unit-tests:
+    # Runs for all supported Django/Python versions
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10']
-        django-version: ['2.2', '3.1', '3.2']
+        django-version: ['2.2', '3.1', '3.2', '4.0']
         os: [
           ubuntu-20.04,
         ]
+        exclude:
+          - python-version: '3.7'
+            django-version: '4.0'
+          - python-version: '3.10'
+            django-version: '2.2'
+          - python-version: '3.10'
+            django-version: '3.1'
 
     steps:
     - uses: actions/checkout@v1
@@ -24,7 +32,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install django==${{ matrix.django-version }} coverage
+        pip install Django==${{ matrix.django-version }} coverage
         python setup.py install
 
     - name: Run coverage
@@ -33,12 +41,18 @@ jobs:
     - name: Upload Coverage to Codecov
       uses: codecov/codecov-action@v1
 
-  unit-tests-dj4:
+
+  unit-tests-future-versions:
+    # Runs for all Django/Python versions which are not yet supported
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         python-version: ['3.8', '3.9', '3.10']
+        django-version: [
+          'Django==4.1',
+          'https://github.com/django/django/archive/main.tar.gz'
+        ]
         os: [
           ubuntu-20.04,
         ]
@@ -53,11 +67,12 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install "django>=4.0,<4.1" coverage
+        pip install ${{ matrix.django-version }} coverage
         python setup.py install
 
     - name: Run coverage
       run: coverage run setup.py test
+      continue-on-error: true
 
     - name: Upload Coverage to Codecov
       uses: codecov/codecov-action@v1

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ Changelog
 unreleased
 ==========
 
+* Start testing Django 4.1 and Django's `main` branch
+
 3.0.1 2022-02-01
 ================
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
     flake8
     isort
     py{37,38,39}-dj{22,31,32}
-    py{38,39,310}-dj{31,32,40}
+    py{38,39,310}-dj{31,32,40,41,main}
 
 skip_missing_interpreters=True
 
@@ -14,11 +14,19 @@ deps =
     dj31: Django>=3.1,<3.2
     dj32: Django>=3.2,<3.3
     dj40: Django>=4.0,<4.1
+    dj41: Django>=4.1,<4.2
+    djmain: https://github.com/django/django/archive/main.tar.gz
 commands =
     {envpython} --version
     {env:COMMAND:coverage} erase
     {env:COMMAND:coverage} run setup.py test
     {env:COMMAND:coverage} report
+ignore_outcome =
+    dj41: True
+    djmain: True
+ignore_errors =
+    dj41: True
+    djmain: True
 
 [testenv:flake8]
 deps = flake8


### PR DESCRIPTION
## Description

Figured before tackling #84 I thought it'd be worth running the test suite over Django 4.1 (and as a bonus over the `main` Django branch)

- renames the `unit-tests-dj4` job to `unit-tests-future-versions`, with the intent being that these are fine to fail since this package doesn't officially support them yet, however it's a good early indicator if this stops being compatible with an upcoming version of Django. I moved Django 4.0 up into the main `unit-tests` matrix since this package works fine on 4.0
- Stop running GH action matrix over unsupported versions (eg. Django 2.2 doesn't need to be run against Python 3.10 since it's not actually supported)
- Add Django 4.1 and main branch to tox but ignore their failures, no point forcing contributors to make their feature/bug work on unsupported versions (or once these are passing we could consider not ignoring them)


## Related resources

<details><summary>Screenshot of tox output</summary>

You can see that tox failed for Django 4.1 and main branch

![2022-09-09_10-54](https://user-images.githubusercontent.com/1423728/189435332-0dcd3ab8-4f39-44cf-bb6f-864ab321b919.png)

</details>

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) ~~and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.~~
